### PR TITLE
chore: improve boilerplate scaffold configuration with confirm prompts and default path

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -14,22 +14,26 @@ variables:
     description: "Is this a hub configuration?"
     type: bool
     default: false
+    confirm: true
   - name: tags
     order: 1
     description: "Tags"
     type: map
     default: {}
+    confirm: true
   # End - Generic Boilerplate Variables Setup
   - name: artifact_bucket_dependency
     order: 2
     description: "Dependency reference for the artifact bucket module output."
     type: bool
     default: false
+    confirm: true
   - name: artifact_bucket_path
     order: 3
     description: "Path to the artifact bucket module output in the dependency configuration."
     type: string
-    default: ""
+    default: "../bucket"
+    confirm: true
 
 hooks:
   after:

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -33,7 +33,6 @@ dependency "artifact_bucket" {
   }
 }
 {{ end }}
-
 include "root" {
   path = find_in_parent_folders("{{ .RootFileName }}")
 }


### PR DESCRIPTION
## Summary

- Add confirm: true to is_hub, tags, artifact_bucket_dependency, artifact_bucket_path variables
- Set default value for artifact_bucket_path from empty string to "../bucket"
- Remove extra blank line after conditional block in terragrunt.hcl template

+semver: patch