### PR TITLE
fix: correct S3 IAM policy for Synthetics canary role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -34,20 +34,37 @@ data "aws_iam_policy_document" "assume_role_policy" {
 data "aws_iam_policy_document" "synthetic_policy" {
   for_each = local.synth_groups
   statement {
-    sid    = "AllowS3Access"
+    sid    = "AllowS3ListBuckets"
+    effect = "Allow"
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+    # ListAllMyBuckets (ListBuckets API) is an account-level action and must use "*"
+    resources = ["*"]
+  }
+  statement {
+    sid    = "AllowS3BucketAccess"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:GetBucketAcl",
+    ]
+    resources = [
+      var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn,
+    ]
+  }
+  statement {
+    sid    = "AllowS3ObjectAccess"
     effect = "Allow"
     actions = [
       "s3:GetObject",
       "s3:GetObjectVersion",
       "s3:PutObject",
-      "s3:ListBucket",
-      "s3:GetBucketLocation",
-      "s3:ListAllMyBuckets",
     ]
     resources = [
-      var.create_artifacts_bucket ? local.created_artifacts_bucket : data.aws_s3_bucket.artifacts[0].arn,
-      "${var.create_artifacts_bucket ? local.created_artifacts_bucket : data.aws_s3_bucket.artifacts[0].arn}/canary/${data.aws_region.current.id}/*",
-      "${var.create_artifacts_bucket ? local.created_artifacts_bucket : data.aws_s3_bucket.artifacts[0].arn}/upload/scripts/*"
+      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/canary/${data.aws_region.current.id}/*",
+      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/upload/scripts/*",
     ]
   }
   statement {


### PR DESCRIPTION
## Summary

- Fix `AccessDenied: ListBuckets` error in Synthetics canary S3 uploader setup: `s3:ListAllMyBuckets` is an account-level action that must use resource `"*"` — it was incorrectly scoped to a specific bucket ARN, causing the Synthetics runtime to be denied when calling the `ListBuckets` API to determine bucket ownership
- Fix bucket ARN reference: `local.created_artifacts_bucket` is a bucket name string, not an ARN; replaced with `module.synthetics_artifacts.s3_bucket_arn` so all bucket-level and object-level IAM policies resolve to valid ARNs
- Add `s3:GetBucketAcl` to bucket-level permissions so the Synthetics runtime can verify bucket ownership before configuring the artifact uploader
- Split single `AllowS3Access` statement into three properly scoped statements: `AllowS3ListBuckets` (`*`), `AllowS3BucketAccess` (bucket ARN), `AllowS3ObjectAccess` (object ARNs)

+semver: fix