### PR TITLE
fix: replace deprecated data.aws_region.current.id with .region for AWS provider v6

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "synthetic_policy" {
       "s3:PutObject",
     ]
     resources = [
-      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/canary/${data.aws_region.current.id}/*",
+      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/canary/${data.aws_region.current.region}/*",
       "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/upload/scripts/*",
     ]
   }
@@ -76,8 +76,8 @@ data "aws_iam_policy_document" "synthetic_policy" {
       "logs:PutLogEvents",
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-*",
-      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-*:*"
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-*",
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-*:*"
     ]
   }
   statement {

--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@
 #
 
 locals {
-  region_arr        = split("-", data.aws_region.current.id)
+  region_arr        = split("-", data.aws_region.current.region)
   region            = format("%s%s%s", lower(local.region_arr[0]), lower(substr(local.region_arr[1], 0, 2)), lower(local.region_arr[2]))
   system_name       = format("%s-%s-%s-%s-%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type), var.spoke_def, local.region)
   system_name_short = format("%s-%s-%s-%s-%s", substr(lower(var.org.organization_unit), 0, 3), substr(lower(var.org.environment_name), 0, 3), substr(lower(replace(var.org.environment_type, "-", "")), 0, 4), var.spoke_def, local.region)


### PR DESCRIPTION
## Summary

- Replace `data.aws_region.current.id` with `data.aws_region.current.region` in `iam.tf` (IAM policy ARN interpolations for S3 and CloudWatch Logs)
- Replace `data.aws_region.current.id` with `data.aws_region.current.region` in `locals.tf` (region_arr split used to derive short region code)
- Both `.id` and `.name` are deprecated in hashicorp/aws >= 6.49.0; `.region` is the current non-deprecated attribute on the `aws_region` data source

+semver: fix