### PR TITLE
feat: evolve synthetics canary compatibility and provider parity

### DIFF
--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -6,6 +6,21 @@ vpc:
   vpc_id: ""                # (Required) VPC ID to deploy canaries into
   subnet_ids: []            # (Required) List of subnet IDs for canary execution
   security_group_ids: []    # (Optional) Additional security group IDs, defaults to []
+  ipv6_allowed_for_dual_stack: null # (Optional) Allow IPv6 for dual-stack VPC canaries, defaults to null/provider default
+
+# canary_defaults: (Optional) Module-level defaults for canary provider options and request validation
+#canary_defaults:
+#  validation_mode: null                       # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
+#  artifact_config:
+#    s3_encryption:
+#      encryption_mode: null                   # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to provider default
+#      kms_key_arn: null                       # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
+#  run_config:
+#    ephemeral_storage_mb: null                # (Optional) Ephemeral storage in MB, minimum 1024, defaults to provider default
+#  schedule_retry:
+#    max_retries: null                         # (Optional) Max schedule retry attempts, defaults to provider default
+#  vpc:
+#    ipv6_allowed_for_dual_stack: null         # (Optional) Allow IPv6 for dual-stack VPC canaries, defaults to null/provider default
 
 # groups: (Optional) Canary groups and canaries configuration, defaults to []
 #groups:
@@ -13,11 +28,20 @@ vpc:
 #    tags: {}                                     # (Optional) Additional tags for the group
 #    vpc:
 #      enabled: true                              # (Optional) Override VPC for group, defaults to true
+#      ipv6_allowed_for_dual_stack: null          # (Optional) Allow IPv6 for dual-stack canaries in this group, defaults to module VPC setting
+#    default_artifact_config:
+#      s3_encryption:
+#        encryption_mode: null                    # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to module/provider default
+#        kms_key_arn: null                        # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
 #    default_run_config:
 #      environment_variables: {}                  # (Optional) Environment variables, defaults to {}
 #      timeout: null                              # (Optional) Timeout in seconds, defaults to null
 #      memory_mb: null                            # (Optional) Memory in MB, defaults to null
 #      tracing: null                              # (Optional) Enable X-Ray tracing, defaults to null
+#      ephemeral_storage_mb: null                 # (Optional) Ephemeral storage in MB, minimum 1024, defaults to module/provider default
+#    default_schedule_retry:
+#      max_retries: null                          # (Optional) Max schedule retry attempts, defaults to module/provider default
+#    validation_mode: null                        # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
 #    canaries:
 #      - name: ""                                 # (Required) Canary name (alphanumeric + hyphens)
 #        description: ""                          # (Optional) Canary description
@@ -25,18 +49,25 @@ vpc:
 #        tags: {}                                 # (Optional) Additional tags for the canary
 #        preserve_lambda: false                   # (Optional) Preserve Lambda after deletion, defaults to false
 #        runtime_version: ""                      # (Optional) AWS Synthetics runtime version. Defaults by requests_type:
-#                                                 #   URL      → syn-python-selenium-6.0  (handler: canary_handler.handler)
-#                                                 #   API      → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-#                                                 #   JSURL    → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-#                                                 #   TRACEURL → syn-nodejs-puppeteer-10.0 (handler: trace_canary_handler.handler)
-#                                                 #   SCRIPT   → syn-nodejs-puppeteer-10.0 (handler: custom_handler.handler)
+#                                                 #   URL      → syn-python-selenium-11.0  (handler: canary_handler.handler)
+#                                                 #   API      → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+#                                                 #   JSURL    → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+#                                                 #   TRACEURL → syn-nodejs-puppeteer-16.0 (handler: trace_canary_handler.handler)
+#                                                 #   SCRIPT   → syn-nodejs-puppeteer-16.0 (handler: custom_handler.handler)
 #                                                 # Override only when targeting a specific runtime version.
 #        handler: ""                              # (Optional) Override the canary handler function. Defaults per requests_type above.
+#        validation_mode: null                    # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
+#        artifact_config:
+#          s3_encryption:
+#            encryption_mode: null                # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to group/module/provider default
+#            kms_key_arn: null                    # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
 #        schedule_expression: "rate(5 minutes)"  # (Optional) CloudWatch schedule expression, defaults to "rate(5 minutes)"
 #        schedule_duration: null                  # (Optional) Duration in seconds for schedule, defaults to null
+#        schedule_retry:
+#          max_retries: null                      # (Optional) Max schedule retry attempts, defaults to group/module/provider default
 #        success_retention_period: 1              # (Optional) Days to retain successful run artifacts, defaults to 1
 #        failure_retention_period: 1              # (Optional) Days to retain failed run artifacts, defaults to 1
-#        requests_type: "URL"                     # (Required) Request type: URL | SCRIPT | API | JSURL | TRACEURL
+#        requests_type: "URL"                     # (Required) Request type: URL | SCRIPT | API | JSURL | TRACEURL | HTTP | HTTP_API | BROWSER_URL | BROWSER_SCRIPT
 #        request_script: ""                       # (Optional) Inline script content, required if requests_type is SCRIPT
 #        request_script_ref: ""                   # (Optional) Script name reference (from request_scripts var), alternative to request_script.
 #                                                 #   When set, runtime_version and handler are inherited from the referenced script definition.
@@ -58,6 +89,7 @@ vpc:
 #          timeout: null                          # (Optional) Timeout in seconds, defaults to null
 #          memory_mb: null                        # (Optional) Memory in MB, defaults to null
 #          tracing: null                          # (Optional) Enable X-Ray tracing, defaults to null
+#          ephemeral_storage_mb: null             # (Optional) Ephemeral storage in MB, minimum 1024, defaults to group/module/provider default
 #        alarms:
 #          enabled: true                          # (Optional) Create alarms for canary, defaults to true
 #          priority: 4                            # (Optional) Alarm priority 1-5, defaults to 4
@@ -93,8 +125,14 @@ vpc:
 #  - name: ""                                # (Required) Script reference name, used in canary.request_script_ref
 #    content: |                              # (Required) Script content (Python/Node.js)
 #    runtime_version: ""                     # (Required) AWS Synthetics runtime version for this script
-#                                            #   e.g., syn-python-selenium-6.0 or syn-nodejs-puppeteer-10.0
+#                                            #   e.g., syn-python-selenium-11.0 or syn-nodejs-puppeteer-16.0
 #    handler: ""                             # (Optional) Handler function name, defaults to custom_handler.handler
+
+# artifact_output_prefix: (Optional) Prefix under the artifacts bucket for canary run artifacts, defaults to bucket root
+#artifact_output_prefix: ""
+
+# code_package_prefix: (Optional) Prefix under the artifacts bucket for uploaded canary code packages, defaults to "upload/scripts"
+#code_package_prefix: "upload/scripts"
 
 # artifacts_bucket: (Optional) S3 bucket ID for storing canary run artifacts, defaults to ""
 # Note: Auto-populated from dependency output when artifact_bucket_dependency=true at scaffold time

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ AWS Observability Synthetics Module for comprehensive monitoring and testing inf
 - CloudWatch metrics integration and alarm management
 - SNS notifications with priority-based routing
 - Artifact management with S3 bucket integration
+- Artifact encryption, package prefix, and run artifact prefix controls
 - Flexible scheduling with cron and rate expressions
+- Schedule retry and runtime ephemeral storage configuration
 - Environment variable configuration for runtime parameters
 - Organized canary grouping for logical separation
 - Customizable retention policies for test artifacts
@@ -61,6 +63,7 @@ Core Features:
 - Organized canary groups with logical separation and tagging
 - VPC-based execution with automated security group management
 - Flexible scheduling using cron or rate expressions
+- Schedule retry configuration for provider-supported retry behavior
 - Configurable retention policies for artifacts and results
 
 Monitoring Capabilities:
@@ -80,6 +83,7 @@ Observability Features:
 - Priority-based alarms (P1-P5)
 - Multiple SNS topic support
 - Custom S3 artifact storage
+- S3 artifact encryption and prefix separation for code packages and run artifacts
 - Environment variable configuration
 
 ## Usage
@@ -119,6 +123,21 @@ vpc:
   vpc_id: ""                # (Required) VPC ID to deploy canaries into
   subnet_ids: []            # (Required) List of subnet IDs for canary execution
   security_group_ids: []    # (Optional) Additional security group IDs, defaults to []
+  ipv6_allowed_for_dual_stack: null # (Optional) Allow IPv6 for dual-stack VPC canaries, defaults to null/provider default
+
+# canary_defaults: (Optional) Module-level defaults for canary provider options and request validation
+#canary_defaults:
+#  validation_mode: null                       # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
+#  artifact_config:
+#    s3_encryption:
+#      encryption_mode: null                   # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to provider default
+#      kms_key_arn: null                       # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
+#  run_config:
+#    ephemeral_storage_mb: null                # (Optional) Ephemeral storage in MB, minimum 1024, defaults to provider default
+#  schedule_retry:
+#    max_retries: null                         # (Optional) Max schedule retry attempts, defaults to provider default
+#  vpc:
+#    ipv6_allowed_for_dual_stack: null         # (Optional) Allow IPv6 for dual-stack VPC canaries, defaults to null/provider default
 
 # groups: (Optional) Canary groups and canaries configuration, defaults to []
 #groups:
@@ -126,11 +145,20 @@ vpc:
 #    tags: {}                                     # (Optional) Additional tags for the group
 #    vpc:
 #      enabled: true                              # (Optional) Override VPC for group, defaults to true
+#      ipv6_allowed_for_dual_stack: null          # (Optional) Allow IPv6 for dual-stack canaries in this group, defaults to module VPC setting
+#    default_artifact_config:
+#      s3_encryption:
+#        encryption_mode: null                    # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to module/provider default
+#        kms_key_arn: null                        # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
 #    default_run_config:
 #      environment_variables: {}                  # (Optional) Environment variables, defaults to {}
 #      timeout: null                              # (Optional) Timeout in seconds, defaults to null
 #      memory_mb: null                            # (Optional) Memory in MB, defaults to null
 #      tracing: null                              # (Optional) Enable X-Ray tracing, defaults to null
+#      ephemeral_storage_mb: null                 # (Optional) Ephemeral storage in MB, minimum 1024, defaults to module/provider default
+#    default_schedule_retry:
+#      max_retries: null                          # (Optional) Max schedule retry attempts, defaults to module/provider default
+#    validation_mode: null                        # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
 #    canaries:
 #      - name: ""                                 # (Required) Canary name (alphanumeric + hyphens)
 #        description: ""                          # (Optional) Canary description
@@ -138,29 +166,36 @@ vpc:
 #        tags: {}                                 # (Optional) Additional tags for the canary
 #        preserve_lambda: false                   # (Optional) Preserve Lambda after deletion, defaults to false
 #        runtime_version: ""                      # (Optional) AWS Synthetics runtime version. Defaults by requests_type:
-#                                                 #   URL      → syn-python-selenium-6.0  (handler: canary_handler.handler)
-#                                                 #   API      → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-#                                                 #   JSURL    → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-#                                                 #   TRACEURL → syn-nodejs-puppeteer-10.0 (handler: trace_canary_handler.handler)
-#                                                 #   SCRIPT   → syn-nodejs-puppeteer-10.0 (handler: custom_handler.handler)
+#                                                 #   URL      → syn-python-selenium-11.0  (handler: canary_handler.handler)
+#                                                 #   API      → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+#                                                 #   JSURL    → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+#                                                 #   TRACEURL → syn-nodejs-puppeteer-16.0 (handler: trace_canary_handler.handler)
+#                                                 #   SCRIPT   → syn-nodejs-puppeteer-16.0 (handler: custom_handler.handler)
 #                                                 # Override only when targeting a specific runtime version.
 #        handler: ""                              # (Optional) Override the canary handler function. Defaults per requests_type above.
-#        schedule_expression: "rate(5 minutes)"  # (Optional) Schedule expression, defaults to "rate(5 minutes)"
+#        validation_mode: null                    # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
+#        artifact_config:
+#          s3_encryption:
+#            encryption_mode: null                # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to group/module/provider default
+#            kms_key_arn: null                    # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
+#        schedule_expression: "rate(5 minutes)"  # (Optional) CloudWatch schedule expression, defaults to "rate(5 minutes)"
 #        schedule_duration: null                  # (Optional) Duration in seconds for schedule, defaults to null
-#        success_retention_period: 1              # (Optional) Days to retain successful artifacts, defaults to 1
-#        failure_retention_period: 1              # (Optional) Days to retain failed artifacts, defaults to 1
-#        requests_type: "URL"                     # (Required) Request type: URL | SCRIPT | API | JSURL | TRACEURL
+#        schedule_retry:
+#          max_retries: null                      # (Optional) Max schedule retry attempts, defaults to group/module/provider default
+#        success_retention_period: 1              # (Optional) Days to retain successful run artifacts, defaults to 1
+#        failure_retention_period: 1              # (Optional) Days to retain failed run artifacts, defaults to 1
+#        requests_type: "URL"                     # (Required) Request type: URL | SCRIPT | API | JSURL | TRACEURL | HTTP | HTTP_API | BROWSER_URL | BROWSER_SCRIPT
 #        request_script: ""                       # (Optional) Inline script content, required if requests_type is SCRIPT
-#        request_script_ref: ""                   # (Optional) Script reference name (from request_scripts).
-#                                                 #   When set, runtime_version and handler are inherited from the referenced script.
+#        request_script_ref: ""                   # (Optional) Script name reference (from request_scripts var), alternative to request_script.
+#                                                 #   When set, runtime_version and handler are inherited from the referenced script definition.
 #        requests:
 #          - url: ""                              # (Required if requests_type is URL/API) Endpoint URL
 #            timeout: 30                          # (Optional) Request timeout in seconds, defaults to 30
-#            method: "GET"                        # (Optional) HTTP method: GET | POST | PUT | DELETE
+#            method: "GET"                        # (Optional) HTTP method: GET | POST | PUT | DELETE, defaults to GET
 #            headers: {}                          # (Optional) Request headers, defaults to {}
 #            body: ""                             # (Optional) Request body, required if method is POST/PUT
 #            assertions:
-#              - type: "STATUS_CODE"              # (Required) Type: STATUS_CODE | RESPONSE_TIME
+#              - type: "STATUS_CODE"              # (Required) Assertion type: STATUS_CODE | RESPONSE_TIME
 #                operator: "EQUALS"               # (Required) Operator: EQUALS | NOT_EQUALS | GREATER_THAN | LESS_THAN
 #                value: 200                       # (Required) Expected value
 #            retry:
@@ -171,6 +206,7 @@ vpc:
 #          timeout: null                          # (Optional) Timeout in seconds, defaults to null
 #          memory_mb: null                        # (Optional) Memory in MB, defaults to null
 #          tracing: null                          # (Optional) Enable X-Ray tracing, defaults to null
+#          ephemeral_storage_mb: null             # (Optional) Ephemeral storage in MB, minimum 1024, defaults to group/module/provider default
 #        alarms:
 #          enabled: true                          # (Optional) Create alarms for canary, defaults to true
 #          priority: 4                            # (Optional) Alarm priority 1-5, defaults to 4
@@ -178,7 +214,7 @@ vpc:
 #          evaluation_periods: "1"               # (Optional) Evaluation periods, defaults to "1"
 #          period: "900"                         # (Optional) Period in seconds, defaults to "900" (15 min)
 #          threshold: "90"                       # (Optional) SuccessPercent threshold, defaults to "90"
-#          metric: "SuccessPercent"              # (Optional) Metric: SuccessPercent | Failed | Duration
+#          metric: "SuccessPercent"              # (Optional) CloudWatch metric: SuccessPercent | Failed | Duration
 #          condition: "LessThanThreshold"        # (Optional) Alarm condition, defaults to "LessThanThreshold"
 #          statistic: "Average"                  # (Optional) Statistic: Average | Sum | Minimum | Maximum
 #          notifications:
@@ -188,7 +224,7 @@ vpc:
 # default_sns_topic_name: (Optional) Default SNS topic name for alarm notifications, defaults to ""
 #default_sns_topic_name: ""
 
-# create_alarms: (Optional) Create CloudWatch alarms for all canaries, defaults to true
+# create_alarms: (Optional) Create CloudWatch alarms for all Synthetics canaries, defaults to true
 #create_alarms: true
 
 # alarms_defaults: (Optional) Default CloudWatch alarm settings applied to all canaries
@@ -199,21 +235,27 @@ vpc:
 #  threshold: "90"                           # (Optional) Alarm threshold percentage, defaults to "90"
 #  metric: "SuccessPercent"                  # (Optional) Metric name, defaults to "SuccessPercent"
 #  condition: "LessThanThreshold"            # (Optional) Alarm condition, defaults to "LessThanThreshold"
-#  description: "This alarm is triggered when the canary fails."
+#  description: "This alarm is triggered when the canary fails." # (Optional) Default alarm description
 
 # request_scripts: (Optional) Reusable script definitions referenced by canaries via request_script_ref, defaults to []
 #request_scripts:
 #  - name: ""                                # (Required) Script reference name, used in canary.request_script_ref
 #    content: |                              # (Required) Script content (Python/Node.js)
 #    runtime_version: ""                     # (Required) AWS Synthetics runtime version for this script
-#                                            #   e.g., syn-python-selenium-6.0 or syn-nodejs-puppeteer-10.0
+#                                            #   e.g., syn-python-selenium-11.0 or syn-nodejs-puppeteer-16.0
 #    handler: ""                             # (Optional) Handler function name, defaults to custom_handler.handler
+
+# artifact_output_prefix: (Optional) Prefix under the artifacts bucket for canary run artifacts, defaults to bucket root
+#artifact_output_prefix: ""
+
+# code_package_prefix: (Optional) Prefix under the artifacts bucket for uploaded canary code packages, defaults to "upload/scripts"
+#code_package_prefix: "upload/scripts"
 
 # artifacts_bucket: (Optional) S3 bucket ID for storing canary run artifacts, defaults to ""
 # Note: Auto-populated from dependency output when artifact_bucket_dependency=true at scaffold time
 #artifacts_bucket: ""
 
-# create_artifacts_bucket: (Optional) Create a dedicated S3 artifacts bucket, defaults to false
+# create_artifacts_bucket: (Optional) Create a dedicated S3 bucket for artifacts, defaults to false
 # Note: Set to false automatically when artifact_bucket_dependency=true at scaffold time
 #create_artifacts_bucket: false
 ```
@@ -255,13 +297,16 @@ inputs = {
   is_hub    = false
   org       = local.env_vars.org
   spoke_def = local.spoke_vars.spoke
-  vpc                     = local.local_vars.vpc
-  groups                  = try(local.local_vars.groups, [])
-  default_sns_topic_name  = try(local.local_vars.default_sns_topic_name, "")
-  create_alarms           = try(local.local_vars.create_alarms, true)
-  alarms_defaults         = try(local.local_vars.alarms_defaults, {})
-  request_scripts         = try(local.local_vars.request_scripts, [])
-  artifacts_bucket        = try(local.local_vars.artifacts_bucket, "")
+  vpc                    = local.local_vars.vpc
+  groups                 = try(local.local_vars.groups, [])
+  default_sns_topic_name = try(local.local_vars.default_sns_topic_name, "")
+  create_alarms          = try(local.local_vars.create_alarms, true)
+  alarms_defaults        = try(local.local_vars.alarms_defaults, {})
+  request_scripts        = try(local.local_vars.request_scripts, [])
+  canary_defaults        = try(local.local_vars.canary_defaults, {})
+  artifact_output_prefix = try(local.local_vars.artifact_output_prefix, "")
+  code_package_prefix    = try(local.local_vars.code_package_prefix, "upload/scripts")
+  artifacts_bucket       = try(local.local_vars.artifacts_bucket, "")
   create_artifacts_bucket = try(local.local_vars.create_artifacts_bucket, false)
   extra_tags = local.tags
 }
@@ -293,12 +338,15 @@ added and `artifacts_bucket` / `create_artifacts_bucket` are wired to the depend
        - "subnet-0abc123"
        - "subnet-0def456"
 
+   artifacts_bucket: "example-synthetics-artifacts"
+   artifact_output_prefix: "synthetics/artifacts"
+   code_package_prefix: "synthetics/packages"
+
    groups:
      - name: "api-monitoring"
        canaries:
          - name: "api-health"
-           runtime_version: "syn-python-selenium-6.0"
-           requests_type: "API"
+           requests_type: "HTTP_API"
            requests:
              - url: "https://api.example.com/health"
                method: "GET"
@@ -309,7 +357,7 @@ added and `artifacts_bucket` / `create_artifacts_bucket` are wired to the depend
 
    create_alarms: true
    default_sns_topic_name: "monitoring-alerts"
-   create_artifacts_bucket: true
+   create_artifacts_bucket: false
    ```
 
 4. Apply configuration:
@@ -327,43 +375,71 @@ added and `artifacts_bucket` / `create_artifacts_bucket` are wired to the depend
 
 ## Examples
 
-```hcl
-module "synthetics" {
-  source = "cloudopsworks/terraform-module-aws-observability-synthetics"
+The following `inputs.yaml` example uses generic names and endpoints and can be applied
+from a directory produced by `terragrunt scaffold`:
 
-  groups = [
-    {
-      name = "api-monitoring"
-      canaries = [
-        {
-          name = "api-health"
-          requests_type = "API"
-          requests = [
-            {
-              url = "https://api.example.com/v1/status"
-              method = "GET"
-              assertions = [
-                {
-                  type = "STATUS_CODE"
-                  operator = "EQUALS"
-                  value = 200
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+```yaml
+vpc:
+  enabled: true
+  vpc_id: "vpc-00000000000000000"
+  subnet_ids:
+    - "subnet-00000000000000001"
+    - "subnet-00000000000000002"
+  security_group_ids:
+    - "sg-00000000000000000"
 
-  vpc = {
-    vpc_id = "vpc-1234567"
-    subnet_ids = ["subnet-abcdef"]
-  }
+artifacts_bucket: "example-synthetics-artifacts"
+artifact_output_prefix: "synthetics/artifacts"
+code_package_prefix: "synthetics/packages"
 
-  artifacts_bucket = "my-artifacts-bucket"
-  sns_topic_name = "monitoring-alerts"
-}
+canary_defaults:
+  artifact_config:
+    s3_encryption:
+      encryption_mode: "SSE_S3"
+  run_config:
+    ephemeral_storage_mb: 1024
+  schedule_retry:
+    max_retries: 1
+
+request_scripts:
+  - name: "browser-script"
+    runtime_version: "syn-nodejs-puppeteer-16.0"
+    handler: "custom_handler.handler"
+    content: |
+      exports.handler = async () => {
+        console.log("generic browser script");
+        return true;
+      };
+
+groups:
+  - name: "external-checks"
+    vpc:
+      enabled: false
+    canaries:
+      - name: "home-page"
+        requests_type: "BROWSER_SCRIPT"
+        request_script_ref: "browser-script"
+
+  - name: "private-api"
+    vpc:
+      enabled: true
+    default_run_config:
+      tracing: true
+      timeout: 60
+      memory_mb: 1024
+    canaries:
+      - name: "post-check"
+        requests_type: "HTTP_API"
+        requests:
+          - url: "https://api.example.org/v1/check"
+            method: "POST"
+            headers:
+              Content-Type: "application/json"
+            body: "{\"request\":\"example\",\"secret\":\"REDACTED\"}"
+            assertions:
+              - type: "STATUS_CODE"
+                operator: "EQUALS"
+                value: 202
 ```
 
 
@@ -395,10 +471,10 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -448,7 +524,10 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarms_defaults"></a> [alarms\_defaults](#input\_alarms\_defaults) | (optional) Default settings for CloudWatch alarms | <pre>object({<br/>    enabled            = optional(bool, true)<br/>    evaluation_periods = optional(string, "1")<br/>    period             = optional(string, "900")<br/>    threshold          = optional(string, "90")<br/>    metric             = optional(string, "SuccessPercent")<br/>    condition          = optional(string, "LessThanThreshold")<br/>    description        = optional(string, "This alarm is triggered when the canary fails.")<br/>  })</pre> | `{}` | no |
+| <a name="input_artifact_output_prefix"></a> [artifact\_output\_prefix](#input\_artifact\_output\_prefix) | (optional) Prefix under the artifacts bucket for AWS Synthetics run artifacts, defaults to the bucket root | `string` | `""` | no |
 | <a name="input_artifacts_bucket"></a> [artifacts\_bucket](#input\_artifacts\_bucket) | (optional) S3 bucket for storing Synthetics canary artifacts | `string` | `""` | no |
+| <a name="input_canary_defaults"></a> [canary\_defaults](#input\_canary\_defaults) | (optional) Module-level defaults for Synthetics canary provider options and validation behavior | <pre>object({<br/>    validation_mode = optional(string)<br/>    artifact_config = optional(object({<br/>      s3_encryption = optional(object({<br/>        encryption_mode = optional(string)<br/>        kms_key_arn     = optional(string)<br/>      }))<br/>    }), {})<br/>    run_config = optional(object({<br/>      ephemeral_storage_mb = optional(number)<br/>    }), {})<br/>    schedule_retry = optional(object({<br/>      max_retries = optional(number)<br/>    }), {})<br/>    vpc = optional(object({<br/>      ipv6_allowed_for_dual_stack = optional(bool)<br/>    }), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_code_package_prefix"></a> [code\_package\_prefix](#input\_code\_package\_prefix) | (optional) Prefix under the artifacts bucket for uploaded canary code packages, defaults to upload/scripts | `string` | `"upload/scripts"` | no |
 | <a name="input_create_alarms"></a> [create\_alarms](#input\_create\_alarms) | (optional) Flag to create CloudWatch alarms for the Synthetics canaries, defaults to true | `bool` | `true` | no |
 | <a name="input_create_artifacts_bucket"></a> [create\_artifacts\_bucket](#input\_create\_artifacts\_bucket) | (optional) Flag to create the S3 bucket for Synthetics canary artifacts, required if artifacts\_bucket is not provided | `bool` | `false` | no |
 | <a name="input_default_sns_topic_name"></a> [default\_sns\_topic\_name](#input\_default\_sns\_topic\_name) | (optional) Name of the SNS topic for notifications, defaults to empty string | `string` | `""` | no |
@@ -456,18 +535,18 @@ Available targets:
 | <a name="input_groups"></a> [groups](#input\_groups) | Settings for the synthetics configurations | `any` | `[]` | no |
 | <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Is this a hub or spoke configuration? | `bool` | `false` | no |
 | <a name="input_org"></a> [org](#input\_org) | Organization details | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
-| <a name="input_request_scripts"></a> [request\_scripts](#input\_request\_scripts) | (optional) Array of request scripts for the Synthetics canaries | <pre>list(object({<br/>    name            = string<br/>    content         = string<br/>    runtime_version = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_request_scripts"></a> [request\_scripts](#input\_request\_scripts) | (optional) Array of request scripts for the Synthetics canaries | <pre>list(object({<br/>    name            = string<br/>    content         = string<br/>    runtime_version = string<br/>    handler         = optional(string, "custom_handler.handler")<br/>  }))</pre> | `[]` | no |
 | <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | Spoke ID Number, must be a 3 digit number | `string` | `"001"` | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | (required) VPC configuration for the Synthetics canaries | <pre>object({<br/>    enabled            = optional(bool, true)<br/>    vpc_id             = optional(string, "")<br/>    subnet_ids         = optional(list(string), [])<br/>    security_group_ids = optional(list(string), [])<br/>  })</pre> | n/a | yes |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | (required) VPC configuration for the Synthetics canaries | <pre>object({<br/>    enabled                     = optional(bool, true)<br/>    vpc_id                      = optional(string, "")<br/>    subnet_ids                  = optional(list(string), [])<br/>    security_group_ids          = optional(list(string), [])<br/>    ipv6_allowed_for_dual_stack = optional(bool)<br/>  })</pre> | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_artifacts_bucket_arn"></a> [artifacts\_bucket\_arn](#output\_artifacts\_bucket\_arn) | n/a |
-| <a name="output_artifacts_bucket_name"></a> [artifacts\_bucket\_name](#output\_artifacts\_bucket\_name) | n/a |
-| <a name="output_synthetics_canaries"></a> [synthetics\_canaries](#output\_synthetics\_canaries) | n/a |
-| <a name="output_synthetics_groups"></a> [synthetics\_groups](#output\_synthetics\_groups) | n/a |
+| <a name="output_artifacts_bucket_arn"></a> [artifacts\_bucket\_arn](#output\_artifacts\_bucket\_arn) | ARN of the S3 artifacts bucket created by this module, or null when an existing bucket is used. |
+| <a name="output_artifacts_bucket_name"></a> [artifacts\_bucket\_name](#output\_artifacts\_bucket\_name) | Name of the S3 artifacts bucket created by this module, or null when an existing bucket is used. |
+| <a name="output_synthetics_canaries"></a> [synthetics\_canaries](#output\_synthetics\_canaries) | Synthetics canaries created by this module with their group names, map keys, names, ARNs, status, and timeline. |
+| <a name="output_synthetics_groups"></a> [synthetics\_groups](#output\_synthetics\_groups) | Synthetics groups created by this module with their map keys, names, and ARNs. |
 
 
 

--- a/README.md
+++ b/README.md
@@ -471,10 +471,10 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/README.yaml
+++ b/README.yaml
@@ -26,7 +26,9 @@ description: |-
   - CloudWatch metrics integration and alarm management
   - SNS notifications with priority-based routing
   - Artifact management with S3 bucket integration
+  - Artifact encryption, package prefix, and run artifact prefix controls
   - Flexible scheduling with cron and rate expressions
+  - Schedule retry and runtime ephemeral storage configuration
   - Environment variable configuration for runtime parameters
   - Organized canary grouping for logical separation
   - Customizable retention policies for test artifacts
@@ -39,6 +41,7 @@ introduction: |-
   - Organized canary groups with logical separation and tagging
   - VPC-based execution with automated security group management
   - Flexible scheduling using cron or rate expressions
+  - Schedule retry configuration for provider-supported retry behavior
   - Configurable retention policies for artifacts and results
 
   Monitoring Capabilities:
@@ -58,6 +61,7 @@ introduction: |-
   - Priority-based alarms (P1-P5)
   - Multiple SNS topic support
   - Custom S3 artifact storage
+  - S3 artifact encryption and prefix separation for code packages and run artifacts
   - Environment variable configuration
 
 # How to use this project
@@ -92,6 +96,21 @@ usage: |-
     vpc_id: ""                # (Required) VPC ID to deploy canaries into
     subnet_ids: []            # (Required) List of subnet IDs for canary execution
     security_group_ids: []    # (Optional) Additional security group IDs, defaults to []
+    ipv6_allowed_for_dual_stack: null # (Optional) Allow IPv6 for dual-stack VPC canaries, defaults to null/provider default
+
+  # canary_defaults: (Optional) Module-level defaults for canary provider options and request validation
+  #canary_defaults:
+  #  validation_mode: null                       # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
+  #  artifact_config:
+  #    s3_encryption:
+  #      encryption_mode: null                   # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to provider default
+  #      kms_key_arn: null                       # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
+  #  run_config:
+  #    ephemeral_storage_mb: null                # (Optional) Ephemeral storage in MB, minimum 1024, defaults to provider default
+  #  schedule_retry:
+  #    max_retries: null                         # (Optional) Max schedule retry attempts, defaults to provider default
+  #  vpc:
+  #    ipv6_allowed_for_dual_stack: null         # (Optional) Allow IPv6 for dual-stack VPC canaries, defaults to null/provider default
 
   # groups: (Optional) Canary groups and canaries configuration, defaults to []
   #groups:
@@ -99,11 +118,20 @@ usage: |-
   #    tags: {}                                     # (Optional) Additional tags for the group
   #    vpc:
   #      enabled: true                              # (Optional) Override VPC for group, defaults to true
+  #      ipv6_allowed_for_dual_stack: null          # (Optional) Allow IPv6 for dual-stack canaries in this group, defaults to module VPC setting
+  #    default_artifact_config:
+  #      s3_encryption:
+  #        encryption_mode: null                    # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to module/provider default
+  #        kms_key_arn: null                        # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
   #    default_run_config:
   #      environment_variables: {}                  # (Optional) Environment variables, defaults to {}
   #      timeout: null                              # (Optional) Timeout in seconds, defaults to null
   #      memory_mb: null                            # (Optional) Memory in MB, defaults to null
   #      tracing: null                              # (Optional) Enable X-Ray tracing, defaults to null
+  #      ephemeral_storage_mb: null                 # (Optional) Ephemeral storage in MB, minimum 1024, defaults to module/provider default
+  #    default_schedule_retry:
+  #      max_retries: null                          # (Optional) Max schedule retry attempts, defaults to module/provider default
+  #    validation_mode: null                        # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
   #    canaries:
   #      - name: ""                                 # (Required) Canary name (alphanumeric + hyphens)
   #        description: ""                          # (Optional) Canary description
@@ -111,29 +139,36 @@ usage: |-
   #        tags: {}                                 # (Optional) Additional tags for the canary
   #        preserve_lambda: false                   # (Optional) Preserve Lambda after deletion, defaults to false
   #        runtime_version: ""                      # (Optional) AWS Synthetics runtime version. Defaults by requests_type:
-  #                                                 #   URL      → syn-python-selenium-6.0  (handler: canary_handler.handler)
-  #                                                 #   API      → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-  #                                                 #   JSURL    → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-  #                                                 #   TRACEURL → syn-nodejs-puppeteer-10.0 (handler: trace_canary_handler.handler)
-  #                                                 #   SCRIPT   → syn-nodejs-puppeteer-10.0 (handler: custom_handler.handler)
+  #                                                 #   URL      → syn-python-selenium-11.0  (handler: canary_handler.handler)
+  #                                                 #   API      → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+  #                                                 #   JSURL    → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+  #                                                 #   TRACEURL → syn-nodejs-puppeteer-16.0 (handler: trace_canary_handler.handler)
+  #                                                 #   SCRIPT   → syn-nodejs-puppeteer-16.0 (handler: custom_handler.handler)
   #                                                 # Override only when targeting a specific runtime version.
   #        handler: ""                              # (Optional) Override the canary handler function. Defaults per requests_type above.
-  #        schedule_expression: "rate(5 minutes)"  # (Optional) Schedule expression, defaults to "rate(5 minutes)"
+  #        validation_mode: null                    # (Optional) Validation mode: legacy | strict. Defaults by requests_type alias.
+  #        artifact_config:
+  #          s3_encryption:
+  #            encryption_mode: null                # (Optional) Artifact encryption mode: SSE_S3 | SSE_KMS, defaults to group/module/provider default
+  #            kms_key_arn: null                    # (Optional) KMS key ARN when encryption_mode is SSE_KMS, defaults to null
+  #        schedule_expression: "rate(5 minutes)"  # (Optional) CloudWatch schedule expression, defaults to "rate(5 minutes)"
   #        schedule_duration: null                  # (Optional) Duration in seconds for schedule, defaults to null
-  #        success_retention_period: 1              # (Optional) Days to retain successful artifacts, defaults to 1
-  #        failure_retention_period: 1              # (Optional) Days to retain failed artifacts, defaults to 1
-  #        requests_type: "URL"                     # (Required) Request type: URL | SCRIPT | API | JSURL | TRACEURL
+  #        schedule_retry:
+  #          max_retries: null                      # (Optional) Max schedule retry attempts, defaults to group/module/provider default
+  #        success_retention_period: 1              # (Optional) Days to retain successful run artifacts, defaults to 1
+  #        failure_retention_period: 1              # (Optional) Days to retain failed run artifacts, defaults to 1
+  #        requests_type: "URL"                     # (Required) Request type: URL | SCRIPT | API | JSURL | TRACEURL | HTTP | HTTP_API | BROWSER_URL | BROWSER_SCRIPT
   #        request_script: ""                       # (Optional) Inline script content, required if requests_type is SCRIPT
-  #        request_script_ref: ""                   # (Optional) Script reference name (from request_scripts).
-  #                                                 #   When set, runtime_version and handler are inherited from the referenced script.
+  #        request_script_ref: ""                   # (Optional) Script name reference (from request_scripts var), alternative to request_script.
+  #                                                 #   When set, runtime_version and handler are inherited from the referenced script definition.
   #        requests:
   #          - url: ""                              # (Required if requests_type is URL/API) Endpoint URL
   #            timeout: 30                          # (Optional) Request timeout in seconds, defaults to 30
-  #            method: "GET"                        # (Optional) HTTP method: GET | POST | PUT | DELETE
+  #            method: "GET"                        # (Optional) HTTP method: GET | POST | PUT | DELETE, defaults to GET
   #            headers: {}                          # (Optional) Request headers, defaults to {}
   #            body: ""                             # (Optional) Request body, required if method is POST/PUT
   #            assertions:
-  #              - type: "STATUS_CODE"              # (Required) Type: STATUS_CODE | RESPONSE_TIME
+  #              - type: "STATUS_CODE"              # (Required) Assertion type: STATUS_CODE | RESPONSE_TIME
   #                operator: "EQUALS"               # (Required) Operator: EQUALS | NOT_EQUALS | GREATER_THAN | LESS_THAN
   #                value: 200                       # (Required) Expected value
   #            retry:
@@ -144,6 +179,7 @@ usage: |-
   #          timeout: null                          # (Optional) Timeout in seconds, defaults to null
   #          memory_mb: null                        # (Optional) Memory in MB, defaults to null
   #          tracing: null                          # (Optional) Enable X-Ray tracing, defaults to null
+  #          ephemeral_storage_mb: null             # (Optional) Ephemeral storage in MB, minimum 1024, defaults to group/module/provider default
   #        alarms:
   #          enabled: true                          # (Optional) Create alarms for canary, defaults to true
   #          priority: 4                            # (Optional) Alarm priority 1-5, defaults to 4
@@ -151,7 +187,7 @@ usage: |-
   #          evaluation_periods: "1"               # (Optional) Evaluation periods, defaults to "1"
   #          period: "900"                         # (Optional) Period in seconds, defaults to "900" (15 min)
   #          threshold: "90"                       # (Optional) SuccessPercent threshold, defaults to "90"
-  #          metric: "SuccessPercent"              # (Optional) Metric: SuccessPercent | Failed | Duration
+  #          metric: "SuccessPercent"              # (Optional) CloudWatch metric: SuccessPercent | Failed | Duration
   #          condition: "LessThanThreshold"        # (Optional) Alarm condition, defaults to "LessThanThreshold"
   #          statistic: "Average"                  # (Optional) Statistic: Average | Sum | Minimum | Maximum
   #          notifications:
@@ -161,7 +197,7 @@ usage: |-
   # default_sns_topic_name: (Optional) Default SNS topic name for alarm notifications, defaults to ""
   #default_sns_topic_name: ""
 
-  # create_alarms: (Optional) Create CloudWatch alarms for all canaries, defaults to true
+  # create_alarms: (Optional) Create CloudWatch alarms for all Synthetics canaries, defaults to true
   #create_alarms: true
 
   # alarms_defaults: (Optional) Default CloudWatch alarm settings applied to all canaries
@@ -172,21 +208,27 @@ usage: |-
   #  threshold: "90"                           # (Optional) Alarm threshold percentage, defaults to "90"
   #  metric: "SuccessPercent"                  # (Optional) Metric name, defaults to "SuccessPercent"
   #  condition: "LessThanThreshold"            # (Optional) Alarm condition, defaults to "LessThanThreshold"
-  #  description: "This alarm is triggered when the canary fails."
+  #  description: "This alarm is triggered when the canary fails." # (Optional) Default alarm description
 
   # request_scripts: (Optional) Reusable script definitions referenced by canaries via request_script_ref, defaults to []
   #request_scripts:
   #  - name: ""                                # (Required) Script reference name, used in canary.request_script_ref
   #    content: |                              # (Required) Script content (Python/Node.js)
   #    runtime_version: ""                     # (Required) AWS Synthetics runtime version for this script
-  #                                            #   e.g., syn-python-selenium-6.0 or syn-nodejs-puppeteer-10.0
+  #                                            #   e.g., syn-python-selenium-11.0 or syn-nodejs-puppeteer-16.0
   #    handler: ""                             # (Optional) Handler function name, defaults to custom_handler.handler
+
+  # artifact_output_prefix: (Optional) Prefix under the artifacts bucket for canary run artifacts, defaults to bucket root
+  #artifact_output_prefix: ""
+
+  # code_package_prefix: (Optional) Prefix under the artifacts bucket for uploaded canary code packages, defaults to "upload/scripts"
+  #code_package_prefix: "upload/scripts"
 
   # artifacts_bucket: (Optional) S3 bucket ID for storing canary run artifacts, defaults to ""
   # Note: Auto-populated from dependency output when artifact_bucket_dependency=true at scaffold time
   #artifacts_bucket: ""
 
-  # create_artifacts_bucket: (Optional) Create a dedicated S3 artifacts bucket, defaults to false
+  # create_artifacts_bucket: (Optional) Create a dedicated S3 bucket for artifacts, defaults to false
   # Note: Set to false automatically when artifact_bucket_dependency=true at scaffold time
   #create_artifacts_bucket: false
   ```
@@ -228,13 +270,16 @@ usage: |-
     is_hub    = false
     org       = local.env_vars.org
     spoke_def = local.spoke_vars.spoke
-    vpc                     = local.local_vars.vpc
-    groups                  = try(local.local_vars.groups, [])
-    default_sns_topic_name  = try(local.local_vars.default_sns_topic_name, "")
-    create_alarms           = try(local.local_vars.create_alarms, true)
-    alarms_defaults         = try(local.local_vars.alarms_defaults, {})
-    request_scripts         = try(local.local_vars.request_scripts, [])
-    artifacts_bucket        = try(local.local_vars.artifacts_bucket, "")
+    vpc                    = local.local_vars.vpc
+    groups                 = try(local.local_vars.groups, [])
+    default_sns_topic_name = try(local.local_vars.default_sns_topic_name, "")
+    create_alarms          = try(local.local_vars.create_alarms, true)
+    alarms_defaults        = try(local.local_vars.alarms_defaults, {})
+    request_scripts        = try(local.local_vars.request_scripts, [])
+    canary_defaults        = try(local.local_vars.canary_defaults, {})
+    artifact_output_prefix = try(local.local_vars.artifact_output_prefix, "")
+    code_package_prefix    = try(local.local_vars.code_package_prefix, "upload/scripts")
+    artifacts_bucket       = try(local.local_vars.artifacts_bucket, "")
     create_artifacts_bucket = try(local.local_vars.create_artifacts_bucket, false)
     extra_tags = local.tags
   }
@@ -245,43 +290,71 @@ usage: |-
 
 # Example usage
 examples: |-
-  ```hcl
-  module "synthetics" {
-    source = "cloudopsworks/terraform-module-aws-observability-synthetics"
+  The following `inputs.yaml` example uses generic names and endpoints and can be applied
+  from a directory produced by `terragrunt scaffold`:
 
-    groups = [
-      {
-        name = "api-monitoring"
-        canaries = [
-          {
-            name = "api-health"
-            requests_type = "API"
-            requests = [
-              {
-                url = "https://api.example.com/v1/status"
-                method = "GET"
-                assertions = [
-                  {
-                    type = "STATUS_CODE"
-                    operator = "EQUALS"
-                    value = 200
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
+  ```yaml
+  vpc:
+    enabled: true
+    vpc_id: "vpc-00000000000000000"
+    subnet_ids:
+      - "subnet-00000000000000001"
+      - "subnet-00000000000000002"
+    security_group_ids:
+      - "sg-00000000000000000"
 
-    vpc = {
-      vpc_id = "vpc-1234567"
-      subnet_ids = ["subnet-abcdef"]
-    }
+  artifacts_bucket: "example-synthetics-artifacts"
+  artifact_output_prefix: "synthetics/artifacts"
+  code_package_prefix: "synthetics/packages"
 
-    artifacts_bucket = "my-artifacts-bucket"
-    sns_topic_name = "monitoring-alerts"
-  }
+  canary_defaults:
+    artifact_config:
+      s3_encryption:
+        encryption_mode: "SSE_S3"
+    run_config:
+      ephemeral_storage_mb: 1024
+    schedule_retry:
+      max_retries: 1
+
+  request_scripts:
+    - name: "browser-script"
+      runtime_version: "syn-nodejs-puppeteer-16.0"
+      handler: "custom_handler.handler"
+      content: |
+        exports.handler = async () => {
+          console.log("generic browser script");
+          return true;
+        };
+
+  groups:
+    - name: "external-checks"
+      vpc:
+        enabled: false
+      canaries:
+        - name: "home-page"
+          requests_type: "BROWSER_SCRIPT"
+          request_script_ref: "browser-script"
+
+    - name: "private-api"
+      vpc:
+        enabled: true
+      default_run_config:
+        tracing: true
+        timeout: 60
+        memory_mb: 1024
+      canaries:
+        - name: "post-check"
+          requests_type: "HTTP_API"
+          requests:
+            - url: "https://api.example.org/v1/check"
+              method: "POST"
+              headers:
+                Content-Type: "application/json"
+              body: "{\"request\":\"example\",\"secret\":\"REDACTED\"}"
+              assertions:
+                - type: "STATUS_CODE"
+                  operator: "EQUALS"
+                  value: 202
   ```
 
 # How to get started quickly
@@ -307,12 +380,15 @@ quickstart: |-
          - "subnet-0abc123"
          - "subnet-0def456"
 
+     artifacts_bucket: "example-synthetics-artifacts"
+     artifact_output_prefix: "synthetics/artifacts"
+     code_package_prefix: "synthetics/packages"
+
      groups:
        - name: "api-monitoring"
          canaries:
            - name: "api-health"
-             runtime_version: "syn-python-selenium-6.0"
-             requests_type: "API"
+             requests_type: "HTTP_API"
              requests:
                - url: "https://api.example.com/health"
                  method: "GET"
@@ -323,7 +399,7 @@ quickstart: |-
 
      create_alarms: true
      default_sns_topic_name: "monitoring-alerts"
-     create_artifacts_bucket: true
+     create_artifacts_bucket: false
      ```
 
   4. Apply configuration:

--- a/alarms.tf
+++ b/alarms.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -69,18 +69,22 @@ resource "aws_cloudwatch_metric_alarm" "canary_failed" {
   alarm_actions = concat(
     [
       for key, topic in local.sns_topics_arns : topic.arn
+      if topic.key == each.key
     ],
     [
       for key, topic in local.sns_topics_names : data.aws_sns_topic.topics_by_name[key].arn
+      if topic.key == each.key
     ],
     var.default_sns_topic_name != "" ? [data.aws_sns_topic.default_topic[0].arn] : []
   )
   ok_actions = concat(
     [
       for key, topic in local.sns_topics_arns : topic.arn
+      if topic.key == each.key
     ],
     [
       for key, topic in local.sns_topics_names : data.aws_sns_topic.topics_by_name[key].arn
+      if topic.key == each.key
     ],
     var.default_sns_topic_name != "" ? [data.aws_sns_topic.default_topic[0].arn] : []
   )

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,10 +13,10 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -66,7 +66,10 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarms_defaults"></a> [alarms\_defaults](#input\_alarms\_defaults) | (optional) Default settings for CloudWatch alarms | <pre>object({<br/>    enabled            = optional(bool, true)<br/>    evaluation_periods = optional(string, "1")<br/>    period             = optional(string, "900")<br/>    threshold          = optional(string, "90")<br/>    metric             = optional(string, "SuccessPercent")<br/>    condition          = optional(string, "LessThanThreshold")<br/>    description        = optional(string, "This alarm is triggered when the canary fails.")<br/>  })</pre> | `{}` | no |
+| <a name="input_artifact_output_prefix"></a> [artifact\_output\_prefix](#input\_artifact\_output\_prefix) | (optional) Prefix under the artifacts bucket for AWS Synthetics run artifacts, defaults to the bucket root | `string` | `""` | no |
 | <a name="input_artifacts_bucket"></a> [artifacts\_bucket](#input\_artifacts\_bucket) | (optional) S3 bucket for storing Synthetics canary artifacts | `string` | `""` | no |
+| <a name="input_canary_defaults"></a> [canary\_defaults](#input\_canary\_defaults) | (optional) Module-level defaults for Synthetics canary provider options and validation behavior | <pre>object({<br/>    validation_mode = optional(string)<br/>    artifact_config = optional(object({<br/>      s3_encryption = optional(object({<br/>        encryption_mode = optional(string)<br/>        kms_key_arn     = optional(string)<br/>      }))<br/>    }), {})<br/>    run_config = optional(object({<br/>      ephemeral_storage_mb = optional(number)<br/>    }), {})<br/>    schedule_retry = optional(object({<br/>      max_retries = optional(number)<br/>    }), {})<br/>    vpc = optional(object({<br/>      ipv6_allowed_for_dual_stack = optional(bool)<br/>    }), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_code_package_prefix"></a> [code\_package\_prefix](#input\_code\_package\_prefix) | (optional) Prefix under the artifacts bucket for uploaded canary code packages, defaults to upload/scripts | `string` | `"upload/scripts"` | no |
 | <a name="input_create_alarms"></a> [create\_alarms](#input\_create\_alarms) | (optional) Flag to create CloudWatch alarms for the Synthetics canaries, defaults to true | `bool` | `true` | no |
 | <a name="input_create_artifacts_bucket"></a> [create\_artifacts\_bucket](#input\_create\_artifacts\_bucket) | (optional) Flag to create the S3 bucket for Synthetics canary artifacts, required if artifacts\_bucket is not provided | `bool` | `false` | no |
 | <a name="input_default_sns_topic_name"></a> [default\_sns\_topic\_name](#input\_default\_sns\_topic\_name) | (optional) Name of the SNS topic for notifications, defaults to empty string | `string` | `""` | no |
@@ -74,15 +77,15 @@
 | <a name="input_groups"></a> [groups](#input\_groups) | Settings for the synthetics configurations | `any` | `[]` | no |
 | <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Is this a hub or spoke configuration? | `bool` | `false` | no |
 | <a name="input_org"></a> [org](#input\_org) | Organization details | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
-| <a name="input_request_scripts"></a> [request\_scripts](#input\_request\_scripts) | (optional) Array of request scripts for the Synthetics canaries | <pre>list(object({<br/>    name            = string<br/>    content         = string<br/>    runtime_version = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_request_scripts"></a> [request\_scripts](#input\_request\_scripts) | (optional) Array of request scripts for the Synthetics canaries | <pre>list(object({<br/>    name            = string<br/>    content         = string<br/>    runtime_version = string<br/>    handler         = optional(string, "custom_handler.handler")<br/>  }))</pre> | `[]` | no |
 | <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | Spoke ID Number, must be a 3 digit number | `string` | `"001"` | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | (required) VPC configuration for the Synthetics canaries | <pre>object({<br/>    enabled            = optional(bool, true)<br/>    vpc_id             = optional(string, "")<br/>    subnet_ids         = optional(list(string), [])<br/>    security_group_ids = optional(list(string), [])<br/>  })</pre> | n/a | yes |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | (required) VPC configuration for the Synthetics canaries | <pre>object({<br/>    enabled                     = optional(bool, true)<br/>    vpc_id                      = optional(string, "")<br/>    subnet_ids                  = optional(list(string), [])<br/>    security_group_ids          = optional(list(string), [])<br/>    ipv6_allowed_for_dual_stack = optional(bool)<br/>  })</pre> | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_artifacts_bucket_arn"></a> [artifacts\_bucket\_arn](#output\_artifacts\_bucket\_arn) | n/a |
-| <a name="output_artifacts_bucket_name"></a> [artifacts\_bucket\_name](#output\_artifacts\_bucket\_name) | n/a |
-| <a name="output_synthetics_canaries"></a> [synthetics\_canaries](#output\_synthetics\_canaries) | n/a |
-| <a name="output_synthetics_groups"></a> [synthetics\_groups](#output\_synthetics\_groups) | n/a |
+| <a name="output_artifacts_bucket_arn"></a> [artifacts\_bucket\_arn](#output\_artifacts\_bucket\_arn) | ARN of the S3 artifacts bucket created by this module, or null when an existing bucket is used. |
+| <a name="output_artifacts_bucket_name"></a> [artifacts\_bucket\_name](#output\_artifacts\_bucket\_name) | Name of the S3 artifacts bucket created by this module, or null when an existing bucket is used. |
+| <a name="output_synthetics_canaries"></a> [synthetics\_canaries](#output\_synthetics\_canaries) | Synthetics canaries created by this module with their group names, map keys, names, ARNs, status, and timeline. |
+| <a name="output_synthetics_groups"></a> [synthetics\_groups](#output\_synthetics\_groups) | Synthetics groups created by this module with their map keys, names, and ARNs. |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,10 +13,10 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.5 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/iam.tf
+++ b/iam.tf
@@ -63,8 +63,8 @@ data "aws_iam_policy_document" "synthetic_policy" {
       "s3:PutObject",
     ]
     resources = [
-      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/canary/${data.aws_region.current.region}/*",
-      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/upload/scripts/*",
+      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/${local.artifact_iam_path}",
+      "${var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : data.aws_s3_bucket.artifacts[0].arn}/${local.code_package_prefix}/*",
     ]
   }
   statement {

--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@
 #
 
 locals {
-  region_arr        = split("-", data.aws_region.current.region)  # id & name are deprecated from v6.47.0, use region instead
+  region_arr        = split("-", data.aws_region.current.region) # id & name are deprecated from v6.47.0, use region instead
   region            = format("%s%s%s", lower(local.region_arr[0]), lower(substr(local.region_arr[1], 0, 2)), lower(local.region_arr[2]))
   system_name       = format("%s-%s-%s-%s-%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type), var.spoke_def, local.region)
   system_name_short = format("%s-%s-%s-%s-%s", substr(lower(var.org.organization_unit), 0, 3), substr(lower(var.org.environment_name), 0, 3), substr(lower(replace(var.org.environment_type, "-", "")), 0, 4), var.spoke_def, local.region)

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -8,6 +8,23 @@
 #
 
 locals {
+  request_type_alias_map = {
+    HTTP           = "URL"
+    HTTP_API       = "API"
+    BROWSER_URL    = "JSURL"
+    BROWSER_SCRIPT = "SCRIPT"
+  }
+  strict_request_type_aliases = keys(local.request_type_alias_map)
+  supported_validation_modes  = ["legacy", "strict"]
+  supported_http_methods      = ["GET", "POST", "PUT", "DELETE"]
+  supported_assertion_types   = ["STATUS_CODE", "RESPONSE_TIME"]
+  supported_assertion_ops     = ["EQUALS", "NOT_EQUALS", "GREATER_THAN", "LESS_THAN"]
+
+  artifact_output_prefix = trim(var.artifact_output_prefix, "/")
+  code_package_prefix    = trim(var.code_package_prefix, "/")
+  artifact_s3_location   = local.artifact_output_prefix == "" ? "s3://${local.s3_location_bucket_name}" : "s3://${local.s3_location_bucket_name}/${local.artifact_output_prefix}"
+  artifact_iam_path      = local.artifact_output_prefix == "" ? "canary/${data.aws_region.current.region}/*" : "${local.artifact_output_prefix}/canary/${data.aws_region.current.region}/*"
+
   script_configuration_map = {
     URL = {
       handler         = "canary_handler.handler"
@@ -39,23 +56,83 @@ locals {
     for script in var.request_scripts : script.name => {
       name            = script.name
       content         = script.content
-      handler         = try(script.handler, "custom_handler.handler")
+      handler         = try(script.handler, "") != "" ? script.handler : "custom_handler.handler"
       runtime_version = script.runtime_version
     }
   }
-  synthetics = merge([
+  synthetics_base = merge([
     for group in var.groups : {
       for canary in group.canaries : "${group.name}-${canary.name}" => {
-        group                = group
-        canary               = canary
-        canary_final_name    = format("synth-%s-%s", canary.name, local.system_name)
-        request_type         = upper(try(canary.requests_type, "URL"))
-        is_nodejs            = strcontains(try(local.request_scripts_map[canary.request_script_ref].runtime_version, canary.runtime_version, local.script_configuration_map[upper(try(canary.requests_type, "URL"))].runtime_version), "nodejs")
-        is_python            = strcontains(try(local.request_scripts_map[canary.request_script_ref].runtime_version, canary.runtime_version, local.script_configuration_map[upper(try(canary.requests_type, "URL"))].runtime_version), "python")
-        script_configuration = local.script_configuration_map[upper(try(canary.requests_type, "URL"))]
+        group             = group
+        canary            = canary
+        canary_final_name = format("synth-%s-%s", canary.name, local.system_name)
+        raw_request_type  = upper(coalesce(try(canary.requests_type, null), "URL"))
+        request_type      = lookup(local.request_type_alias_map, upper(coalesce(try(canary.requests_type, null), "URL")), upper(coalesce(try(canary.requests_type, null), "URL")))
+        validation_mode = lower(coalesce(
+          try(canary.validation_mode != "" ? canary.validation_mode : null, null),
+          try(group.validation_mode != "" ? group.validation_mode : null, null),
+          try(var.canary_defaults.validation_mode != "" ? var.canary_defaults.validation_mode : null, null),
+          contains(local.strict_request_type_aliases, upper(coalesce(try(canary.requests_type, null), "URL"))) ? "strict" : "legacy"
+        ))
+        schedule_max_retries = try(coalesce(
+          try(canary.schedule_retry.max_retries, null),
+          try(group.default_schedule_retry.max_retries, null),
+          try(var.canary_defaults.schedule_retry.max_retries, null)
+        ), null)
+        run_ephemeral_storage_mb = try(coalesce(
+          try(canary.run_config.ephemeral_storage_mb, null),
+          try(group.default_run_config.ephemeral_storage_mb, null),
+          try(var.canary_defaults.run_config.ephemeral_storage_mb, null)
+        ), null)
+        vpc_ipv6_allowed_dual_stack = try(coalesce(
+          try(canary.vpc.ipv6_allowed_for_dual_stack, null),
+          try(group.vpc.ipv6_allowed_for_dual_stack, null),
+          try(var.canary_defaults.vpc.ipv6_allowed_for_dual_stack, null),
+          try(var.vpc.ipv6_allowed_for_dual_stack, null)
+        ), null)
+        artifact_s3_encryption = try(coalesce(
+          try(canary.artifact_config.s3_encryption, null),
+          try(group.default_artifact_config.s3_encryption, null),
+          try(var.canary_defaults.artifact_config.s3_encryption, null)
+        ), null)
+        artifact_s3_encryption_enabled = (
+          try(coalesce(
+            try(canary.artifact_config.s3_encryption.encryption_mode, null),
+            try(group.default_artifact_config.s3_encryption.encryption_mode, null),
+            try(var.canary_defaults.artifact_config.s3_encryption.encryption_mode, null)
+          ), null) != null ||
+          try(coalesce(
+            try(canary.artifact_config.s3_encryption.kms_key_arn, null),
+            try(group.default_artifact_config.s3_encryption.kms_key_arn, null),
+            try(var.canary_defaults.artifact_config.s3_encryption.kms_key_arn, null)
+          ), null) != null
+        )
       }
     }
   ]...)
+  synthetics_runtime_versions = {
+    for key, synthetic in local.synthetics_base : key => coalesce(
+      try(local.request_scripts_map[synthetic.canary.request_script_ref].runtime_version != "" ? local.request_scripts_map[synthetic.canary.request_script_ref].runtime_version : null, null),
+      try(synthetic.canary.runtime_version != "" ? synthetic.canary.runtime_version : null, null),
+      local.script_configuration_map[synthetic.request_type].runtime_version
+    )
+  }
+  synthetics_handlers = {
+    for key, synthetic in local.synthetics_base : key => coalesce(
+      try(synthetic.canary.handler != "" ? synthetic.canary.handler : null, null),
+      try(local.request_scripts_map[synthetic.canary.request_script_ref].handler != "" ? local.request_scripts_map[synthetic.canary.request_script_ref].handler : null, null),
+      local.script_configuration_map[synthetic.request_type].handler
+    )
+  }
+  synthetics = {
+    for key, synthetic in local.synthetics_base : key => merge(synthetic, {
+      script_configuration     = local.script_configuration_map[synthetic.request_type]
+      resolved_runtime_version = local.synthetics_runtime_versions[key]
+      resolved_handler         = local.synthetics_handlers[key]
+      is_nodejs                = strcontains(local.synthetics_runtime_versions[key], "nodejs")
+      is_python                = strcontains(local.synthetics_runtime_versions[key], "python")
+    })
+  }
   synth_groups = {
     for group in var.groups : group.name => group
   }
@@ -81,12 +158,12 @@ resource "aws_synthetics_group" "this" {
 
 resource "aws_synthetics_canary" "this" {
   for_each                 = local.synthetics
-  artifact_s3_location     = "s3://${local.s3_location_bucket_name}"
+  artifact_s3_location     = local.artifact_s3_location
   execution_role_arn       = aws_iam_role.this[each.value.group.name].arn
   name                     = each.value.canary_final_name
   start_canary             = try(each.value.canary.enabled, true)
-  runtime_version          = try(each.value.canary.runtime_version, local.request_scripts_map[each.value.canary.request_script_ref].runtime_version, each.value.script_configuration.runtime_version)
-  handler                  = try(each.value.canary.handler, local.request_scripts_map[each.value.canary.request_script_ref].handler, each.value.script_configuration.handler)
+  runtime_version          = each.value.resolved_runtime_version
+  handler                  = each.value.resolved_handler
   delete_lambda            = !try(each.value.canary.preserve_lambda, false)
   success_retention_period = try(each.value.canary.success_retention_period, 1)
   failure_retention_period = try(each.value.canary.failure_retention_period, 1)
@@ -94,14 +171,31 @@ resource "aws_synthetics_canary" "this" {
   s3_key                   = try(local.zip_files_nodejs[each.key].bucket_key, local.zip_files_python[each.key].bucket_key)
   s3_version               = try(aws_s3_object.script_url_nodejs[each.key].version_id, aws_s3_object.script_url_python[each.key].version_id, aws_s3_object.script_custom[each.key].version_id)
   schedule {
-    expression          = each.value.canary.schedule_expression
+    expression          = try(each.value.canary.schedule_expression, "rate(5 minutes)")
     duration_in_seconds = try(each.value.canary.schedule_duration, null)
+
+    dynamic "retry_config" {
+      for_each = each.value.schedule_max_retries == null ? [] : [each.value.schedule_max_retries]
+      content {
+        max_retries = retry_config.value
+      }
+    }
+  }
+  dynamic "artifact_config" {
+    for_each = each.value.artifact_s3_encryption_enabled ? [each.value.artifact_s3_encryption] : []
+    content {
+      s3_encryption {
+        encryption_mode = try(artifact_config.value.encryption_mode, null)
+        kms_key_arn     = try(artifact_config.value.kms_key_arn, null)
+      }
+    }
   }
   dynamic "vpc_config" {
     for_each = var.vpc.enabled && try(each.value.group.vpc.enabled, true) ? [1] : []
     content {
-      subnet_ids         = var.vpc.subnet_ids
-      security_group_ids = concat(var.vpc.security_group_ids, [aws_security_group.this[each.value.group.name].id])
+      subnet_ids                  = var.vpc.subnet_ids
+      security_group_ids          = concat(var.vpc.security_group_ids, [aws_security_group.this[each.value.group.name].id])
+      ipv6_allowed_for_dual_stack = each.value.vpc_ipv6_allowed_dual_stack
     }
   }
 
@@ -117,6 +211,7 @@ resource "aws_synthetics_canary" "this" {
     timeout_in_seconds = try(each.value.canary.run_config.timeout, each.value.group.default_run_config.timeout, null)
     memory_in_mb       = try(each.value.canary.run_config.memory_mb, each.value.group.default_run_config.memory_mb, null)
     active_tracing     = try(each.value.canary.run_config.tracing, each.value.group.default_run_config.tracing, null)
+    ephemeral_storage  = each.value.run_ephemeral_storage_mb
   }
   tags = merge(
     local.all_tags,
@@ -127,6 +222,35 @@ resource "aws_synthetics_canary" "this" {
       synthetic-canary-key = each.value.canary.name
     }
   )
+  lifecycle {
+    precondition {
+      condition     = contains(local.supported_validation_modes, each.value.validation_mode)
+      error_message = "validation_mode must be legacy or strict."
+    }
+    precondition {
+      condition     = contains(keys(local.script_configuration_map), each.value.request_type)
+      error_message = "requests_type must be one of URL, SCRIPT, API, JSURL, TRACEURL, HTTP, HTTP_API, BROWSER_URL, or BROWSER_SCRIPT."
+    }
+    precondition {
+      condition = each.value.validation_mode == "legacy" || alltrue([
+        for request in try(each.value.canary.requests, []) : (
+          contains(local.supported_http_methods, upper(coalesce(try(request.method, null), "GET"))) &&
+          coalesce(try(request.timeout, null), 30) > 0 &&
+          coalesce(try(request.retry.count, null), 3) >= 1 &&
+          coalesce(try(request.retry.interval, null), 5) >= 0 &&
+          (!contains(["POST", "PUT"], upper(coalesce(try(request.method, null), "GET"))) || try(request.body, null) != null) &&
+          alltrue([
+            for assertion in try(request.assertions, []) : (
+              contains(local.supported_assertion_types, upper(coalesce(try(assertion.type, null), ""))) &&
+              contains(local.supported_assertion_ops, upper(coalesce(try(assertion.operator, null), ""))) &&
+              try(assertion.value, null) != null
+            )
+          ])
+        )
+      ])
+      error_message = "Strict validation requires supported methods, positive timeouts, retry.count >= 1, retry.interval >= 0, POST/PUT bodies, and supported assertions."
+    }
+  }
 }
 
 resource "aws_synthetics_group_association" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -8,14 +8,17 @@
 #
 
 output "artifacts_bucket_name" {
-  value = var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_id : null
+  description = "Name of the S3 artifacts bucket created by this module, or null when an existing bucket is used."
+  value       = var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_id : null
 }
 
 output "artifacts_bucket_arn" {
-  value = var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : null
+  description = "ARN of the S3 artifacts bucket created by this module, or null when an existing bucket is used."
+  value       = var.create_artifacts_bucket ? module.synthetics_artifacts.s3_bucket_arn : null
 }
 
 output "synthetics_groups" {
+  description = "Synthetics groups created by this module with their map keys, names, and ARNs."
   value = [
     for key, group in aws_synthetics_group.this : {
       key  = key
@@ -26,6 +29,7 @@ output "synthetics_groups" {
 }
 
 output "synthetics_canaries" {
+  description = "Synthetics canaries created by this module with their group names, map keys, names, ARNs, status, and timeline."
   value = [
     for key, canary in aws_synthetics_canary.this : {
       group_name = aws_synthetics_group_association.this[key].group_name

--- a/scripts-node.tf
+++ b/scripts-node.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -12,7 +12,7 @@ locals {
     for key, content in local.synthetics : key => {
       file_path     = "${path.module}/sources/standard/${key}/nodejs/"
       file_name     = "${key}_config.yaml"
-      bucket_key    = "upload/scripts/${key}.zip"
+      bucket_key    = "${local.code_package_prefix}/${key}.zip"
       zip_file_path = "${path.module}/scripts/${key}.zip"
     }
     if content.is_nodejs
@@ -45,7 +45,7 @@ resource "local_file" "script_config_nodejs" {
 
 resource "null_resource" "stage_nodejs" {
   triggers = {
-    always = timestamp()
+    scripts_sha = local.nodejs_scripts_sha
   }
   provisioner "local-exec" {
     command     = "npm install --prefix ./stage/nodejs --no-save --no-package-json --no-package-lock --omit=dev --target_arch=x64 --target_platform=linux js-yaml"
@@ -118,7 +118,7 @@ resource "aws_s3_object" "script_url_nodejs" {
 resource "local_file" "script_custom_node" {
   for_each        = local.nodejs_synthetics_custom
   content         = try(local.request_scripts_map[each.value.canary.request_script_ref].content, each.value.canary.request_script)
-  filename        = "${path.module}/sources/custom/${each.key}/nodejs/node_modules/${split(".", try(each.value.canary.handler, each.value.script_configuration.handler))[0]}.js"
+  filename        = "${path.module}/sources/custom/${each.key}/nodejs/node_modules/${split(".", each.value.resolved_handler)[0]}.js"
   file_permission = "0644"
 }
 
@@ -161,4 +161,3 @@ resource "terraform_data" "script_custom_node" {
 #     ]
 #   }
 # }
-

--- a/scripts-python.tf
+++ b/scripts-python.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -31,7 +31,7 @@ locals {
     for key, content in local.synthetics : key => {
       file_path     = "${path.module}/sources/standard/${key}/python/"
       file_name     = "${key}_config.yaml"
-      bucket_key    = "upload/scripts/${key}.zip"
+      bucket_key    = "${local.code_package_prefix}/${key}.zip"
       zip_file_path = "${path.module}/scripts/${key}.zip"
     }
     if content.is_python
@@ -64,7 +64,7 @@ resource "local_file" "script_config_python" {
 
 resource "null_resource" "stage_python" {
   triggers = {
-    always = timestamp()
+    sources_sha = local.hash_sources
   }
   provisioner "local-exec" {
     command     = "python3 -m pip install -r requirements.txt --target ./stage/python --platform manylinux_2_17_x86_64 --python-version 3.11 --implementation cp --only-binary=:all: --no-deps --upgrade"
@@ -117,7 +117,7 @@ resource "aws_s3_object" "script_url_python" {
 resource "local_file" "script_custom_python" {
   for_each        = local.python_synthetics_custom
   content         = try(local.request_scripts_map[each.value.canary.request_script_ref].content, each.value.canary.request_script)
-  filename        = "${path.module}/sources/custom/${each.key}/python/custom_handler.py"
+  filename        = "${path.module}/sources/custom/${each.key}/python/${split(".", each.value.resolved_handler)[0]}.py"
   file_permission = "0644"
 }
 

--- a/tests/fixtures/generic-consumers.tfvars.json
+++ b/tests/fixtures/generic-consumers.tfvars.json
@@ -1,0 +1,201 @@
+{
+  "org": {
+    "organization_name": "example-org",
+    "organization_unit": "observability",
+    "environment_type": "production",
+    "environment_name": "prod"
+  },
+  "spoke_def": "001",
+  "vpc": {
+    "enabled": true,
+    "vpc_id": "vpc-00000000000000000",
+    "subnet_ids": [
+      "subnet-00000000000000001",
+      "subnet-00000000000000002"
+    ],
+    "security_group_ids": [
+      "sg-00000000000000000"
+    ],
+    "ipv6_allowed_for_dual_stack": false
+  },
+  "artifacts_bucket": "example-synthetics-artifacts",
+  "artifact_output_prefix": "synthetics/artifacts",
+  "code_package_prefix": "synthetics/packages",
+  "create_alarms": true,
+  "default_sns_topic_name": "example-default-alerts",
+  "canary_defaults": {
+    "artifact_config": {
+      "s3_encryption": {
+        "encryption_mode": "SSE_S3"
+      }
+    },
+    "run_config": {
+      "ephemeral_storage_mb": 1024
+    },
+    "schedule_retry": {
+      "max_retries": 1
+    },
+    "vpc": {
+      "ipv6_allowed_for_dual_stack": false
+    }
+  },
+  "request_scripts": [
+    {
+      "name": "consumer-a-browser-script",
+      "runtime_version": "syn-nodejs-puppeteer-16.0",
+      "handler": "custom_handler.handler",
+      "content": "exports.handler = async () => { console.log('generic script canary'); return true; };\n"
+    }
+  ],
+  "groups": [
+    {
+      "name": "consumer-a",
+      "tags": {
+        "Consumer": "A"
+      },
+      "vpc": {
+        "enabled": false
+      },
+      "validation_mode": "strict",
+      "canaries": [
+        {
+          "name": "script-ref",
+          "description": "Generic script-backed external check using a reusable script reference.",
+          "requests_type": "BROWSER_SCRIPT",
+          "request_script_ref": "consumer-a-browser-script",
+          "schedule_expression": "rate(5 minutes)",
+          "alarms": {
+            "notifications": [
+              {
+                "sns_topic_name": "consumer-a-alerts"
+              }
+            ]
+          }
+        },
+        {
+          "name": "script-inline",
+          "description": "Generic inline script check with a per-canary handler override.",
+          "requests_type": "SCRIPT",
+          "runtime_version": "syn-nodejs-puppeteer-16.0",
+          "handler": "inline_handler.handler",
+          "request_script": "exports.handler = async () => { console.log('generic inline canary'); return true; };\n",
+          "schedule_expression": "rate(10 minutes)",
+          "alarms": {
+            "notifications": [
+              {
+                "sns_topic_arn": "arn:aws:sns:us-east-1:123456789012:consumer-a-inline-alerts"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "consumer-b",
+      "tags": {
+        "Consumer": "B"
+      },
+      "vpc": {
+        "enabled": true,
+        "ipv6_allowed_for_dual_stack": false
+      },
+      "default_run_config": {
+        "timeout": 60,
+        "memory_mb": 1024,
+        "tracing": true,
+        "ephemeral_storage_mb": 1024
+      },
+      "default_schedule_retry": {
+        "max_retries": 2
+      },
+      "canaries": [
+        {
+          "name": "service-health",
+          "description": "Generic VPC service health check with tracing enabled.",
+          "requests_type": "TRACEURL",
+          "requests": [
+            {
+              "url": "https://service-a.internal.example.net/health",
+              "timeout": 20,
+              "method": "GET",
+              "assertions": [
+                {
+                  "type": "STATUS_CODE",
+                  "operator": "EQUALS",
+                  "value": 200
+                }
+              ],
+              "retry": {
+                "count": 3,
+                "interval": 5
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "consumer-c",
+      "tags": {
+        "Consumer": "C"
+      },
+      "vpc": {
+        "enabled": true
+      },
+      "canaries": [
+        {
+          "name": "private-post",
+          "description": "Generic private-network POST check with non-secret placeholder payload.",
+          "requests_type": "HTTP_API",
+          "requests": [
+            {
+              "url": "https://api.example.org/v1/check",
+              "timeout": 30,
+              "method": "POST",
+              "headers": {
+                "Content-Type": "application/json",
+                "X-Example-Request": "synthetics"
+              },
+              "body": "{\"request\":\"example\",\"secret\":\"REDACTED\"}",
+              "assertions": [
+                {
+                  "type": "STATUS_CODE",
+                  "operator": "EQUALS",
+                  "value": 202
+                },
+                {
+                  "type": "RESPONSE_TIME",
+                  "operator": "LESS_THAN",
+                  "value": 10
+                }
+              ],
+              "retry": {
+                "count": 2,
+                "interval": 10
+              }
+            }
+          ]
+        },
+        {
+          "name": "legacy-invalid-assertion",
+          "description": "Generic legacy-mode compatibility fixture; invalid assertion is intentionally not strict-validated.",
+          "requests_type": "URL",
+          "validation_mode": "legacy",
+          "requests": [
+            {
+              "url": "https://legacy.example.com/status",
+              "method": "GET",
+              "assertions": [
+                {
+                  "type": "HEADER_CONTAINS",
+                  "operator": "EQUALS",
+                  "value": "ok"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/strict-invalid-assertion.tfvars.json
+++ b/tests/fixtures/strict-invalid-assertion.tfvars.json
@@ -1,0 +1,39 @@
+{
+  "org": {
+    "organization_name": "example-org",
+    "organization_unit": "observability",
+    "environment_type": "production",
+    "environment_name": "prod"
+  },
+  "vpc": {
+    "enabled": false,
+    "vpc_id": "vpc-00000000000000000",
+    "subnet_ids": [],
+    "security_group_ids": []
+  },
+  "artifacts_bucket": "example-synthetics-artifacts",
+  "groups": [
+    {
+      "name": "strict-invalid",
+      "canaries": [
+        {
+          "name": "bad-assertion",
+          "requests_type": "HTTP",
+          "requests": [
+            {
+              "url": "https://strict.example.com/status",
+              "method": "GET",
+              "assertions": [
+                {
+                  "type": "HEADER_CONTAINS",
+                  "operator": "EQUALS",
+                  "value": "ok"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generic_provider_parity.tftest.hcl
+++ b/tests/generic_provider_parity.tftest.hcl
@@ -1,0 +1,94 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = {
+      region = "us-east-1"
+    }
+  }
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+  mock_data "aws_s3_bucket" {
+    defaults = {
+      arn = "arn:aws:s3:::example-synthetics-artifacts"
+    }
+  }
+  mock_data "aws_sns_topic" {
+    defaults = {
+      arn = "arn:aws:sns:us-east-1:123456789012:example-alerts"
+    }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/example-synthetics"
+    }
+  }
+}
+
+mock_provider "local" {}
+mock_provider "null" {}
+mock_provider "random" {}
+
+variables {
+  org                    = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).org
+  spoke_def              = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).spoke_def
+  vpc                    = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).vpc
+  artifacts_bucket       = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).artifacts_bucket
+  artifact_output_prefix = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).artifact_output_prefix
+  code_package_prefix    = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).code_package_prefix
+  create_alarms          = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).create_alarms
+  default_sns_topic_name = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).default_sns_topic_name
+  canary_defaults        = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).canary_defaults
+  request_scripts        = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).request_scripts
+  groups                 = jsondecode(file("tests/fixtures/generic-consumers.tfvars.json")).groups
+}
+
+run "generic_consumers_plan" {
+  command = plan
+
+  assert {
+    condition     = length(aws_synthetics_canary.this) == 5
+    error_message = "Expected generic fixture to produce five canaries."
+  }
+
+  assert {
+    condition     = aws_synthetics_canary.this["consumer-a-script-ref"].handler == "custom_handler.handler"
+    error_message = "Reusable script handler should be inherited for Consumer A script-ref."
+  }
+
+  assert {
+    condition     = aws_synthetics_canary.this["consumer-a-script-inline"].handler == "inline_handler.handler"
+    error_message = "Per-canary handler should override default handler for Consumer A inline script."
+  }
+
+  assert {
+    condition     = aws_synthetics_canary.this["consumer-b-service-health"].runtime_version == "syn-nodejs-puppeteer-16.0"
+    error_message = "TRACEURL should retain the Node.js Synthetics runtime."
+  }
+
+  assert {
+    condition     = aws_synthetics_canary.this["consumer-c-private-post"].artifact_s3_location == "s3://example-synthetics-artifacts/synthetics/artifacts"
+    error_message = "Artifact output prefix should be appended to artifact_s3_location."
+  }
+
+  assert {
+    condition     = aws_synthetics_canary.this["consumer-c-private-post"].s3_key == "synthetics/packages/consumer-c-private-post.zip"
+    error_message = "Code package prefix should be applied to canary package keys."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.canary_failed["consumer-a-script-inline"].alarm_actions) == 2
+    error_message = "Consumer A script-inline should include its own SNS topic ARN plus the default topic."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.canary_failed["consumer-b-service-health"].alarm_actions) == 1
+    error_message = "Consumer B alarm should not inherit Consumer A notification topics."
+  }
+}

--- a/tests/strict_validation.tftest.hcl
+++ b/tests/strict_validation.tftest.hcl
@@ -1,0 +1,46 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    defaults = {
+      region = "us-east-1"
+    }
+  }
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+    }
+  }
+  mock_data "aws_s3_bucket" {
+    defaults = {
+      arn = "arn:aws:s3:::example-synthetics-artifacts"
+    }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/example-synthetics"
+    }
+  }
+}
+
+mock_provider "local" {}
+mock_provider "null" {}
+mock_provider "random" {}
+
+variables {
+  org              = jsondecode(file("tests/fixtures/strict-invalid-assertion.tfvars.json")).org
+  vpc              = jsondecode(file("tests/fixtures/strict-invalid-assertion.tfvars.json")).vpc
+  artifacts_bucket = jsondecode(file("tests/fixtures/strict-invalid-assertion.tfvars.json")).artifacts_bucket
+  groups           = jsondecode(file("tests/fixtures/strict-invalid-assertion.tfvars.json")).groups
+}
+
+run "strict_invalid_assertion_fails" {
+  command = plan
+
+  expect_failures = [
+    aws_synthetics_canary.this["strict-invalid-bad-assertion"]
+  ]
+}

--- a/tests/validate_generic_fixtures.py
+++ b/tests/validate_generic_fixtures.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate sanitized generic fixture intent without Terraform/AWS access."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures"
+PRIVATE_MARKERS = (
+    "/users/",
+    "\\users\\",
+    "/work/",
+    "terraform.tfvars",
+    "secret-value",
+)
+
+
+def load(name: str) -> dict:
+    with (FIXTURES / name).open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def walk_strings(value):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from walk_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from walk_strings(item)
+
+
+def canaries(fixture: dict):
+    for group in fixture.get("groups", []):
+        for canary in group.get("canaries", []):
+            yield group, canary
+
+
+def assert_no_private_markers(*fixtures: dict) -> None:
+    for fixture in fixtures:
+        for value in walk_strings(fixture):
+            lowered = value.lower()
+            for marker in PRIVATE_MARKERS:
+                assert marker not in lowered, f"private marker leaked into fixture: {marker}"
+
+
+def main() -> None:
+    generic = load("generic-consumers.tfvars.json")
+    strict_invalid = load("strict-invalid-assertion.tfvars.json")
+    assert_no_private_markers(generic, strict_invalid)
+
+    grouped = {group["name"]: group for group in generic["groups"]}
+    assert set(grouped) == {"consumer-a", "consumer-b", "consumer-c"}
+
+    consumer_a_types = {canary["requests_type"] for canary in grouped["consumer-a"]["canaries"]}
+    assert {"BROWSER_SCRIPT", "SCRIPT"}.issubset(consumer_a_types)
+    assert any("request_script_ref" in canary for canary in grouped["consumer-a"]["canaries"])
+    assert any("request_script" in canary for canary in grouped["consumer-a"]["canaries"])
+    assert any(canary.get("handler") == "inline_handler.handler" for canary in grouped["consumer-a"]["canaries"])
+
+    consumer_b = grouped["consumer-b"]
+    assert consumer_b["vpc"]["enabled"] is True
+    assert consumer_b["default_run_config"]["tracing"] is True
+    assert consumer_b["canaries"][0]["requests_type"] == "TRACEURL"
+
+    consumer_c_canaries = {canary["name"]: canary for canary in grouped["consumer-c"]["canaries"]}
+    post_request = consumer_c_canaries["private-post"]["requests"][0]
+    assert consumer_c_canaries["private-post"]["requests_type"] == "HTTP_API"
+    assert post_request["method"] == "POST"
+    assert "REDACTED" in post_request["body"]
+
+    legacy = consumer_c_canaries["legacy-invalid-assertion"]
+    assert legacy["validation_mode"] == "legacy"
+    assert legacy["requests"][0]["assertions"][0]["type"] == "HEADER_CONTAINS"
+
+    strict_canary = next(canaries(strict_invalid))[1]
+    assert strict_canary["requests_type"] == "HTTP"
+    assert strict_canary["requests"][0]["assertions"][0]["type"] == "HEADER_CONTAINS"
+
+    assert generic["artifact_output_prefix"] == "synthetics/artifacts"
+    assert generic["code_package_prefix"] == "synthetics/packages"
+    assert generic["canary_defaults"]["schedule_retry"]["max_retries"] == 1
+
+
+if __name__ == "__main__":
+    main()

--- a/variables-synth.tf
+++ b/variables-synth.tf
@@ -14,11 +14,20 @@
 #       Environment: "Production"
 #     vpc:
 #       enabled: true | false # (optional) Whether to enable VPC for the group, defaults to true
+#       ipv6_allowed_for_dual_stack: true | false # (optional) Allow IPv6 for dual-stack VPC canaries, defaults to null
+#     default_artifact_config:      # (optional) Default artifact encryption for canaries in the group
+#       s3_encryption:
+#         encryption_mode: "SSE_S3" | "SSE_KMS" # (optional) S3 artifact encryption mode, defaults to provider default
+#         kms_key_arn: ""                       # (optional) KMS key ARN for SSE_KMS artifacts, defaults to null
 #     default_run_config:         # (optional) Default run configuration for the group
 #       environment_variables: {} # (optional) Environment variables for the canary, defaults to empty map
 #       timeout: 60               # (optional) Timeout in seconds for the canary, defaults to null
 #       memory_mb: 128            # (optional) Memory in MB for the canary, defaults to null
 #       tracing: true | false     # (optional) Whether to enable xray tracing, defaults to null
+#       ephemeral_storage_mb: 1024  # (optional) Ephemeral storage in MB for the canary runtime, defaults to provider default
+#     default_schedule_retry:
+#       max_retries: 2             # (optional) Max schedule retry attempts, defaults to provider default
+#     validation_mode: "legacy" | "strict" # (optional) Request DSL validation mode for the group, defaults by request alias
 #     canaries:           # List of canaries in the group
 #       - name: "example-canary"
 #         description: "This is an example canary" # (optional) Description of the canary
@@ -27,17 +36,24 @@
 #           Environment: "Production"
 #         preserve_lambda: true | false # (optional) Whether to preserve the Lambda function after deletion, defaults to false
 #         runtime_version: ""           # (optional) AWS Synthetics runtime version; defaults by requests_type:
-#                                       #   URL      → syn-python-selenium-6.0  (handler: canary_handler.handler)
-#                                       #   API      → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-#                                       #   JSURL    → syn-nodejs-puppeteer-10.0 (handler: canary_handler.handler)
-#                                       #   TRACEURL → syn-nodejs-puppeteer-10.0 (handler: trace_canary_handler.handler)
-#                                       #   SCRIPT   → syn-nodejs-puppeteer-10.0 (handler: custom_handler.handler)
+#                                       #   URL      → syn-python-selenium-11.0  (handler: canary_handler.handler)
+#                                       #   API      → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+#                                       #   JSURL    → syn-nodejs-puppeteer-16.0 (handler: canary_handler.handler)
+#                                       #   TRACEURL → syn-nodejs-puppeteer-16.0 (handler: trace_canary_handler.handler)
+#                                       #   SCRIPT   → syn-nodejs-puppeteer-16.0 (handler: custom_handler.handler)
 #         handler: ""                   # (optional) Override the canary handler function; defaults per requests_type above
+#         validation_mode: "legacy" | "strict" # (optional) Request DSL validation mode, defaults by request alias
+#         artifact_config:              # (optional) Artifact encryption override for this canary
+#           s3_encryption:
+#             encryption_mode: "SSE_S3" | "SSE_KMS" # (optional) S3 artifact encryption mode
+#             kms_key_arn: ""                       # (optional) KMS key ARN for SSE_KMS artifacts
 #         schedule_expression: "rate(5 minutes)" # (optional) Schedule for the canary, defaults to "rate(5 minutes)" or cron expression "cron(0/5 * * * ? *)"
 #         schedule_duration: 300 # (optional) Duration in seconds for the canary schedule, defaults to null
+#         schedule_retry:
+#           max_retries: 2      # (optional) Max schedule retry attempts, defaults to group/module/provider default
 #         success_retention_period: 7 # (optional) Retention period in Days for successful runs, defaults to 1 Day
 #         failure_retention_period: 7 # (optional) Retention period in Days for failed runs, defaults to 1 Day
-#         requests_type: "URL" | "SCRIPT" | "API" | "JSURL" | "TRACEURL" # (required) Type of request, defaults to URL
+#         requests_type: "URL" | "SCRIPT" | "API" | "JSURL" | "TRACEURL" | "HTTP" | "HTTP_API" | "BROWSER_URL" | "BROWSER_SCRIPT" # (required) Type of request, defaults to URL
 #         request_script: |                      # (optional) Script for the canary, required if type is SCRIPT
 #         request_script_ref: "script-name" # (optional) Reference to a script defined in request_scripts; when set, runtime_version and handler are inherited from the referenced script
 #         requests:
@@ -60,6 +76,7 @@
 #           timeout: 60               # (optional) Timeout in seconds for the canary, defaults to null
 #           memory_mb: 128            # (optional) Memory in MB for the canary, defaults to null
 #           tracing: true | false     # (optional) Whether to enable xray tracing, defaults to null
+#           ephemeral_storage_mb: 1024  # (optional) Ephemeral storage in MB for the canary runtime, defaults to provider default
 #         alarms:                 # (optional) Alarms configuration for the canary
 #           enabled: true | false # (optional) Whether to create alarms for the canary, defaults to true
 #           priority: 1           # (optional) Priority of the alarms, defaults to 4
@@ -77,6 +94,74 @@ variable "groups" {
   description = "Settings for the synthetics configurations"
   type        = any
   default     = []
+
+  validation {
+    condition = alltrue(flatten([
+      for group in var.groups : [
+        for canary in try(group.canaries, []) : contains(
+          ["URL", "SCRIPT", "API", "JSURL", "TRACEURL", "HTTP", "HTTP_API", "BROWSER_URL", "BROWSER_SCRIPT"],
+          upper(coalesce(try(canary.requests_type, null), "URL"))
+        )
+      ]
+    ]))
+    error_message = "Each canary requests_type must be one of URL, SCRIPT, API, JSURL, TRACEURL, HTTP, HTTP_API, BROWSER_URL, or BROWSER_SCRIPT."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for group in var.groups : concat(
+        [
+          contains(["legacy", "strict"], lower(coalesce(try(group.validation_mode, null), "legacy")))
+        ],
+        [
+          for canary in try(group.canaries, []) : contains(["legacy", "strict"], lower(coalesce(try(canary.validation_mode, null), "legacy")))
+        ]
+      )
+    ]))
+    error_message = "validation_mode must be legacy or strict when set at group or canary level."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for group in var.groups : concat(
+        [
+          coalesce(try(group.default_schedule_retry.max_retries, null), 0) >= 0
+        ],
+        [
+          for canary in try(group.canaries, []) : coalesce(try(canary.schedule_retry.max_retries, null), 0) >= 0
+        ]
+      )
+    ]))
+    error_message = "schedule_retry.max_retries must be greater than or equal to 0 when set."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for group in var.groups : concat(
+        [
+          coalesce(try(group.default_run_config.ephemeral_storage_mb, null), 1024) >= 1024
+        ],
+        [
+          for canary in try(group.canaries, []) : coalesce(try(canary.run_config.ephemeral_storage_mb, null), 1024) >= 1024
+        ]
+      )
+    ]))
+    error_message = "run_config.ephemeral_storage_mb must be at least 1024 MB when set."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for group in var.groups : concat(
+        [
+          try(contains(["SSE_S3", "SSE_KMS"], upper(group.default_artifact_config.s3_encryption.encryption_mode)), true)
+        ],
+        [
+          for canary in try(group.canaries, []) : try(contains(["SSE_S3", "SSE_KMS"], upper(canary.artifact_config.s3_encryption.encryption_mode)), true)
+        ]
+      )
+    ]))
+    error_message = "artifact_config.s3_encryption.encryption_mode must be SSE_S3 or SSE_KMS when set."
+  }
 }
 
 variable "default_sns_topic_name" {
@@ -112,6 +197,7 @@ variable "request_scripts" {
     name            = string
     content         = string
     runtime_version = string
+    handler         = optional(string, "custom_handler.handler")
   }))
   default = []
 }
@@ -119,11 +205,74 @@ variable "request_scripts" {
 variable "vpc" {
   description = "(required) VPC configuration for the Synthetics canaries"
   type = object({
-    enabled            = optional(bool, true)
-    vpc_id             = optional(string, "")
-    subnet_ids         = optional(list(string), [])
-    security_group_ids = optional(list(string), [])
+    enabled                     = optional(bool, true)
+    vpc_id                      = optional(string, "")
+    subnet_ids                  = optional(list(string), [])
+    security_group_ids          = optional(list(string), [])
+    ipv6_allowed_for_dual_stack = optional(bool)
   })
+}
+
+variable "canary_defaults" {
+  description = "(optional) Module-level defaults for Synthetics canary provider options and validation behavior"
+  type = object({
+    validation_mode = optional(string)
+    artifact_config = optional(object({
+      s3_encryption = optional(object({
+        encryption_mode = optional(string)
+        kms_key_arn     = optional(string)
+      }))
+    }), {})
+    run_config = optional(object({
+      ephemeral_storage_mb = optional(number)
+    }), {})
+    schedule_retry = optional(object({
+      max_retries = optional(number)
+    }), {})
+    vpc = optional(object({
+      ipv6_allowed_for_dual_stack = optional(bool)
+    }), {})
+  })
+  default = {}
+
+  validation {
+    condition     = contains(["legacy", "strict"], lower(coalesce(try(var.canary_defaults.validation_mode, null), "legacy")))
+    error_message = "canary_defaults.validation_mode must be either legacy or strict when set."
+  }
+
+  validation {
+    condition     = try(contains(["SSE_S3", "SSE_KMS"], upper(var.canary_defaults.artifact_config.s3_encryption.encryption_mode)), true)
+    error_message = "canary_defaults.artifact_config.s3_encryption.encryption_mode must be SSE_S3 or SSE_KMS when set."
+  }
+
+  validation {
+    condition     = coalesce(try(var.canary_defaults.schedule_retry.max_retries, null), 0) >= 0
+    error_message = "canary_defaults.schedule_retry.max_retries must be greater than or equal to 0 when set."
+  }
+
+  validation {
+    condition     = coalesce(try(var.canary_defaults.run_config.ephemeral_storage_mb, null), 1024) >= 1024
+    error_message = "canary_defaults.run_config.ephemeral_storage_mb must be at least 1024 MB when set."
+  }
+}
+
+variable "artifact_output_prefix" {
+  description = "(optional) Prefix under the artifacts bucket for AWS Synthetics run artifacts, defaults to the bucket root"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "code_package_prefix" {
+  description = "(optional) Prefix under the artifacts bucket for uploaded canary code packages, defaults to upload/scripts"
+  type        = string
+  default     = "upload/scripts"
+  nullable    = false
+
+  validation {
+    condition     = trim(var.code_package_prefix, "/") != ""
+    error_message = "code_package_prefix must not be empty after trimming leading and trailing slashes."
+  }
 }
 
 variable "artifacts_bucket" {


### PR DESCRIPTION
## Summary

- Add compatibility-first provider parity for AWS Synthetics canaries: artifact encryption, run artifact/package prefixes, schedule retry config, runtime ephemeral storage, and VPC dual-stack flag passthrough.
- Preserve legacy request types while adding strict aliases (`HTTP`, `HTTP_API`, `BROWSER_URL`, `BROWSER_SCRIPT`) with strict validation defaults.
- Fix per-canary alarm notification filtering and add output descriptions.
- Add sanitized generic OpenTofu fixtures/tests for script-backed, VPC health, POST, legacy-invalid, and strict-invalid canary patterns.
- Regenerate README documentation and boilerplate inputs with generic examples only.

## Validation

- `make fmt`
- `make lint`
- `python3 tests/validate_generic_fixtures.py`
- `tofu test -no-color`
- `make readme`
- `git diff --check`

+semver: minor